### PR TITLE
Stop calling rand.Seed inside this pacakge

### DIFF
--- a/net.go
+++ b/net.go
@@ -14,15 +14,16 @@ var randPerm = func(n int) []int {
 type dialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
 
 // DialFunc is a helper function which returns `net.DialContext` function.
-// It randomly fetches an IP from the dns cache and dial it by the given dial
+// It randomly fetches an IP from the DNS cache and dial it by the given dial
 // function. It dials one by one and return first connected `net.Conn`.
 // If it fails to dial all IPs from cache it returns first error. If no baseDialFunc
 // is given, it sets default dial function.
 //
 // You can use returned dial function for `http.Transport.DialContext`.
+//
+// In this fucntion, it uses functions from `rand` package. To make it really random,
+// you MUST call `rand.Seed` and change the value from the default in your application
 func DialFunc(resolver *Resolver, baseDialFunc dialFunc) dialFunc {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	if baseDialFunc == nil {
 		// This is same as which `http.DefaultTransport` uses.
 		baseDialFunc = (&net.Dialer{

--- a/net_example_test.go
+++ b/net_example_test.go
@@ -1,6 +1,7 @@
 package dnscache
 
 import (
+	"math/rand"
 	"net/http"
 	"time"
 
@@ -12,6 +13,7 @@ func ExampleDialFunc() {
 
 	// You can create a HTTP client which selects an IP from dnscache
 	// randomly and dial it.
+	rand.Seed(time.Now().UTC().UnixNano()) // You MUST run in once in your application
 	client := http.Client{
 		Transport: &http.Transport{
 			DialContext: DialFunc(resolver, nil),

--- a/net_test.go
+++ b/net_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"net"
 	"testing"
+	"time"
 )
 
 func TestDialFunc(t *testing.T) {
@@ -75,6 +77,11 @@ func TestDialFunc(t *testing.T) {
 }
 
 func TestDialFuncRand(t *testing.T) {
+	rand.Seed(time.Now().UTC().UnixNano())
+	defer func() {
+		rand.Seed(1)
+	}()
+
 	resolver := &Resolver{
 		cache: map[string][]net.IP{
 			"deeeet.com": []net.IP{


### PR DESCRIPTION
## WHAT

Stop calling `rand.Seed` inside this package. 

## WHY

If we call `rand.Seed` in the package, it makes the application which uses this package makes hard to testing it. 
