### PR TITLE
Add link for circleci to CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# go-dnscache [![Go Documentation](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)][godoc] ![CircleCI (all branches)](https://img.shields.io/circleci/project/github/mercari/go-dnscache.svg?style=flat-square) [![Codecov](https://img.shields.io/codecov/c/github/mercari/go-dnscache.svg?style=flat-square)][codecov]
+# go-dnscache [![Go Documentation](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)][godoc] [![CircleCI (all branches)](https://img.shields.io/circleci/project/github/mercari/go-dnscache.svg?style=flat-square)](circleci) [![Codecov](https://img.shields.io/codecov/c/github/mercari/go-dnscache.svg?style=flat-square)][codecov]
 
 [godoc]: http://godoc.org/go.mercari.io/go-dnscache
+[circleci]: https://circleci.com/gh/mercari/go-dnscache
 [codecov]: https://codecov.io/gh/mercari/go-dnscache
 
 `go-dnscache` is a Go package for caching DNS lookup results in memory. It asynchronously lookups DNS and refresh results. The main motivation of this package is to avoid too much DNS lookups for every requests (DNS lookup sometimes makes request really slow and causes error). This can be mainly used for the targets which are running on *non-dynamic* environment where IP does not change often.


### PR DESCRIPTION
## WHAT

This adds link for circleci to CI badge.

## WHY

Currently we have a link to the static image.